### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
       "node_modules/sqlite3/lib/binding/**/*"
     ],
     "targets": [
-      "node14-macos-arm64",
-      "node14-macos-x64",
-      "node14-windows-x64",
-      "node14-linux-x64",
-      "node14-linux-arm64",
-      "node14-alpine-x64",
-      "node14-alpine-arm64"
+      "node16-macos-arm64",
+      "node16-macos-x64",
+      "node16-windows-x64",
+      "node16-linux-x64",
+      "node16-linux-arm64",
+      "node16-alpine-x64",
+      "node16-alpine-arm64"
     ],
     "outputPath": "dist"
   },


### PR DESCRIPTION
pkg打包后，检查版本更新version.replaceAll is not a function错误，提高pkg打包版本node16